### PR TITLE
Fix(Mobilesync): prevent 'undefined index' when sync security

### DIFF
--- a/inc/mobilesync.class.php
+++ b/inc/mobilesync.class.php
@@ -390,14 +390,14 @@ class PluginJamfMobileSync extends PluginJamfDeviceSync
                 $this->jamfplugin_item_changes['lost_location_date'] = $lost_location_date;
             }
             $this->commondevice_changes['activation_lock_enabled'] = $security['activation_lock_enabled'];
-            $this->jamfplugin_item_changes['lost_mode_enabled'] = $security['lost_mode_enabled'];
-            $this->jamfplugin_item_changes['lost_mode_enforced'] = $security['lost_mode_enforced'];
-            $this->jamfplugin_item_changes['lost_mode_message'] = $security['lost_mode_message'];
-            $this->jamfplugin_item_changes['lost_mode_phone'] = $security['lost_mode_phone'];
-            $this->jamfplugin_item_changes['lost_location_latitude'] = $security['lost_location_latitude'];
-            $this->jamfplugin_item_changes['lost_location_longitude'] = $security['lost_location_longitude'];
-            $this->jamfplugin_item_changes['lost_location_altitude'] = $security['lost_location_altitude'];
-            $this->jamfplugin_item_changes['lost_location_speed'] = $security['lost_location_speed'];
+            $this->jamfplugin_item_changes['lost_mode_enabled'] = $security['lost_mode_enabled'] ?? '';
+            $this->jamfplugin_item_changes['lost_mode_enforced'] = $security['lost_mode_enforced'] ?? 0;
+            $this->jamfplugin_item_changes['lost_mode_message'] = $security['lost_mode_message'] ?? '';
+            $this->jamfplugin_item_changes['lost_mode_phone'] = $security['lost_mode_phone'] ?? '';
+            $this->jamfplugin_item_changes['lost_location_latitude'] = $security['lost_location_latitude'] ?? '';
+            $this->jamfplugin_item_changes['lost_location_longitude'] = $security['lost_location_longitude'] ?? '';
+            $this->jamfplugin_item_changes['lost_location_altitude'] = $security['lost_location_altitude'] ?? '';
+            $this->jamfplugin_item_changes['lost_location_speed'] = $security['lost_location_speed'] ?? '';
         } catch (Exception $e) {
             $this->status['syncSecurity'] = self::STATUS_ERROR;
             return $this;


### PR DESCRIPTION
Prevent PHP warning

```shell
[2024-07-12 15:36:40] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "lost_location_latitude" in /mnt/diskhome/home/htdocs/marketplace/jamf/inc/mobilesync.class.php at line 397
  Backtrace :
  marketplace/jamf/inc/devicesync.class.php:256      PluginJamfMobileSync->syncSecurity()
  marketplace/jamf/ajax/merge.php:130                PluginJamfDeviceSync::sync()
  
[2024-07-12 15:36:40] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "lost_location_longitude" in /mnt/diskhome/home/htdocs/marketplace/jamf/inc/mobilesync.class.php at line 398
  Backtrace :
  marketplace/jamf/inc/devicesync.class.php:256      PluginJamfMobileSync->syncSecurity()
  marketplace/jamf/ajax/merge.php:130                PluginJamfDeviceSync::sync()
  
[2024-07-12 15:36:40] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "lost_location_altitude" in /mnt/diskhome/home/htdocs/marketplace/jamf/inc/mobilesync.class.php at line 399
  Backtrace :
  marketplace/jamf/inc/devicesync.class.php:256      PluginJamfMobileSync->syncSecurity()
  marketplace/jamf/ajax/merge.php:130                PluginJamfDeviceSync::sync()
  
[2024-07-12 15:36:40] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "lost_location_speed" in /mnt/diskhome/home/htdocs/marketplace/jamf/inc/mobilesync.class.php at line 400
  Backtrace :
  marketplace/jamf/inc/devicesync.class.php:256      PluginJamfMobileSync->syncSecurity()
  marketplace/jamf/ajax/merge.php:130                PluginJamfDeviceSync::sync()
  
[2024-07-12 15:36:41] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "lost_mode_enabled" in /mnt/diskhome/home/htdocs/marketplace/jamf/inc/mobilesync.class.php at line 393
  Backtrace :
  marketplace/jamf/inc/devicesync.class.php:256      PluginJamfMobileSync->syncSecurity()
  marketplace/jamf/ajax/merge.php:130                PluginJamfDeviceSync::sync()
  
[2024-07-12 15:36:41] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "lost_mode_enforced" in /mnt/diskhome/home/htdocs/marketplace/jamf/inc/mobilesync.class.php at line 394
  Backtrace :
  marketplace/jamf/inc/devicesync.class.php:256      PluginJamfMobileSync->syncSecurity()
  marketplace/jamf/ajax/merge.php:130                PluginJamfDeviceSync::sync()
  
[2024-07-12 15:36:41] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "lost_mode_message" in /mnt/diskhome/home/htdocs/marketplace/jamf/inc/mobilesync.class.php at line 395
  Backtrace :
  marketplace/jamf/inc/devicesync.class.php:256      PluginJamfMobileSync->syncSecurity()
  marketplace/jamf/ajax/merge.php:130                PluginJamfDeviceSync::sync()
  
[2024-07-12 15:36:41] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "lost_mode_phone" in /mnt/diskhome/home/htdocs/marketplace/jamf/inc/mobilesync.class.php at line 396
  Backtrace :
  marketplace/jamf/inc/devicesync.class.php:256      PluginJamfMobileSync->syncSecurity()
  marketplace/jamf/ajax/merge.php:130                PluginJamfDeviceSync::sync()
  
[2024-07-12 15:36:41] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "lost_location_latitude" in /mnt/diskhome/home/htdocs/marketplace/jamf/inc/mobilesync.class.php at line 397
  Backtrace :
  marketplace/jamf/inc/devicesync.class.php:256      PluginJamfMobileSync->syncSecurity()
  marketplace/jamf/ajax/merge.php:130                PluginJamfDeviceSync::sync()
  
```