### PR TITLE
Fix(Merge): fix table used to update import_date during merge

### DIFF
--- a/ajax/merge.php
+++ b/ajax/merge.php
@@ -127,7 +127,7 @@ if ($_REQUEST['action'] === 'merge') {
 
                 // Update merged device and then delete the pending import
                 if ($sync_result) {
-                    $DB->update($plugin_itemtype::getTable(), [
+                    $DB->update('glpi_plugin_jamf_devices', [
                         'import_date' => $_SESSION['glpi_currenttime']
                     ], [
                         'itemtype' => $itemtype,


### PR DESCRIPTION
Prevent SQL error when merging

```shell
[2024-07-12 15:36:24] glpisqllog.ERROR: DBmysql::doQuery() in /mnt/diskhome/home/osut4b7dfeul/dbn7DcC4Lhp/htdocs/src/DBmysql.php line 403
  *** MySQL query error:
  SQL: UPDATE `glpi_plugin_jamf_mobiledevices` SET `import_date` = '2024-07-12 15:36:13' WHERE `itemtype` = 'Computer' AND `items_id` = '244'
  Error: Unknown column 'itemtype' in 'where clause'
  Backtrace :
  src/DBmysql.php:1503                               DBmysql->doQuery()
  marketplace/jamf/ajax/merge.php:138                DBmysql->update()
```