### PR TITLE
Fix(EventLog): Fix SQL error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - SQL error when merging the Jamf device linked to a GLPI asset
+- SQL error when adding `Event`
 
 ## [3.1.1]
 

--- a/inc/computersync.class.php
+++ b/inc/computersync.class.php
@@ -630,7 +630,7 @@ class PluginJamfComputerSync extends PluginJamfDeviceSync
         ]);
         if ($iterator->count()) {
             // Already imported
-            Event::log(-1, $itemtype, 4, 'Jamf plugin', "Jamf computer $jamf_items_id not imported. A {$itemtype::getTypeName(1)} exists with the same uuid.");
+            Event::log(0, $itemtype, 4, 'Jamf plugin', "Jamf computer $jamf_items_id not imported. A {$itemtype::getTypeName(1)} exists with the same uuid.");
             return false;
         }
 

--- a/inc/mobilesync.class.php
+++ b/inc/mobilesync.class.php
@@ -773,7 +773,7 @@ class PluginJamfMobileSync extends PluginJamfDeviceSync
         }
         if ($iterator->count()) {
             // Already imported
-            Event::log(-1, $itemtype, 4, 'Jamf plugin', "Jamf mobile device $jamf_items_id not imported. A {$itemtype::getTypeName(1)} exists with the same uuid.");
+            Event::log(0, $itemtype, 4, 'Jamf plugin', "Jamf mobile device $jamf_items_id not imported. A {$itemtype::getTypeName(1)} exists with the same uuid.");
             return false;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !32903

Fix SQL error when items_id is `-1`

```shell
[2024-12-26 13:04:44] glpisqllog.WARNING: DBmysql::doQuery() in /mnt/diskhome/home/htdocs/src/DBmysql.php line 438
  *** MySQL query warnings:
  SQL: INSERT INTO `glpi_events` (`items_id`, `type`, `date`, `service`, `level`, `message`) VALUES ('-1', 'Computer', '2024-12-26 13:03:45', 'Jamf plugin', '4', 'Jamf computer 71 not imported. A Computer exists with the same uuid.')
  Warnings: 
1264: Out of range value for column 'items_id' at row 1
  Backtrace :
  src/DBmysql.php:1377                               DBmysql->doQuery()
  src/CommonDBTM.php:730                             DBmysql->insert()
  src/CommonDBTM.php:1349                            CommonDBTM->addToDB()
  src/Event.php:115                                  CommonDBTM->add()
  marketplace/jamf/inc/computersync.class.php:633    Glpi\Event::log()
  marketplace/jamf/ajax/import.php:72                PluginJamfComputerSync::import()
```




## Screenshots (if appropriate):

