### PR TITLE
Fix(API): fix API call during merge request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - SQL error when merging the Jamf device linked to a GLPI asset
 - SQL error when adding `Event`
+- Fix `Computer` merge process
 
 ## [3.1.1]
 

--- a/ajax/merge.php
+++ b/ajax/merge.php
@@ -77,7 +77,12 @@ if ($_REQUEST['action'] === 'merge') {
                 $plugin_sync_itemtype = 'PluginJamfMobileSync';
             }
 
-            $jamf_item = PluginJamfAPI::getMobileDeviceByID($jamf_id, true);
+            if ($data['jamf_type'] === 'MobileDevice') {
+                $jamf_item = PluginJamfAPI::getMobileDeviceByID($jamf_id, true);
+            } else {
+                $jamf_item = PluginJamfAPI::getComputerByID($jamf_id, true);
+            }
+
             if ($jamf_item === null) {
                 // API error or device no longer exists in Jamf
                 throw new RuntimeException('Jamf API error or item no longer exists!');
@@ -87,11 +92,11 @@ if ($_REQUEST['action'] === 'merge') {
             $rules = new PluginJamfRuleImportCollection();
 
             //WTF is this, Jamf?
-            $os_details = $jamf_item['ios'] ?? $jamf_item['tvos'];
+            $os_details = $jamf_item['ios'] ?? $jamf_item['tvos'] ?? '';
             $ruleinput = [
-                'name' => $jamf_item['name'],
+                'name' => $jamf_item['name'] ?? $jamf_item['general']['name'],
                 'itemtype' => $itemtype,
-                'last_inventory' => $jamf_item['lastInventoryUpdateTimestamp'],
+                'last_inventory' => $jamf_item['lastInventoryUpdateTimestamp'] ?? $jamf_item['general']['lastContactTime'],
                 'managed' => $jamf_item['managed'] ?? $os_details['managed'],
                 'supervised' => $jamf_item['supervised'] ?? $os_details['supervised'],
             ];

--- a/inc/api.class.php
+++ b/inc/api.class.php
@@ -496,21 +496,14 @@ class PluginJamfAPI
         return $all_results;
     }
 
-    public static function getComputerByID(int $id, ?string $section = null): ?array
+    public static function getComputerByID(int $id, bool $detailed = false)
     {
         if (!static::$connection) {
             static::$connection = new static::$connection_class();
         }
-        $endpoint = "/v1/computer-inventory";
-        $query_params = [
-            'section' => $section,
-            'filter' => 'id==' . $id
-        ];
-        $response = static::$connection->getClient()->get(static::$connection->getAPIUrl($endpoint, true) . '?' . http_build_query($query_params));
-        $result = json_decode($response->getBody()->getContents(), true);
-        if (isset($result['results']) && count($result['results']) > 0) {
-            return $result['results'][0];
-        }
-        return null;
+        $endpoint = "/v1/computer-inventory" . ($detailed ? '-detail' : '') . "/{$id}";
+        $response = static::$connection->getClient()->get(static::$connection->getAPIUrl($endpoint, true));
+        return json_decode($response->getBody()->getContents(), true);
     }
+
 }

--- a/inc/migration.class.php
+++ b/inc/migration.class.php
@@ -575,7 +575,7 @@ final class PluginJamfMigration
                         }
                     } else if ($device['jamf_type'] === 'Computer') {
                         // We need to query the JSS for the computer's model identifier
-                        $computer = $this->api::getComputerByID($device['jamf_items_id'], 'hardware');
+                        $computer = $this->api::getComputerByID($device['jamf_items_id'], true);
                         if ($computer !== null) {
                             $this->db->update(
                                 'glpi_plugin_jamf_devices',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !32903
- Addition of #6 

Rework `getComputerByID` to match this endpoint `computer-inventory-detail/{id}`

current endpoint `computer-inventory` thrown a 404 not found

```shell
Error during API call: Client error: `GET https://server.jamfcloud.com/api//v1/computer-inventory?section=1&filter=id%3D%3D49` resulted in a `404 Not Found` response:
```

the input data for the rules have been adapted (the schema differs between Mobile and Computer)

There is an example of data return by api with this endpoint
https://community.jamf.com/t5/jamf-pro/jamf-pro-api-v1-computers-inventory-detail-id-cutting-the-json/m-p/323454

## Screenshots (if appropriate):

