### PR TITLE
Allow selecting GLPI itemtype when importing mobile devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [UNRELEASED]
 
+### Added
+- Added support to choose importing/merging mobile devices as Computers or Phones
+
 ### Fixes
 
 - SQL error when merging the Jamf device linked to a GLPI asset

--- a/ajax/import.php
+++ b/ajax/import.php
@@ -56,21 +56,22 @@ if ($_REQUEST['action'] == 'import') {
     if (isset($_REQUEST['import_ids']) && is_array($_REQUEST['import_ids'])) {
         // Get data for each item to import
         $toimport = $DB->request([
-            'SELECT' => ['type', 'jamf_type', 'jamf_items_id'],
-            'FROM'   => PluginJamfImport::getTable(),
-            'WHERE'  => [
-                'id' => $_REQUEST['import_ids'],
-            ],
+            'SELECT' => ['id', 'type', 'jamf_type', 'jamf_items_id'],
+            'FROM' => PluginJamfImport::getTable(),
+            'WHERE' => [
+                'id' => $_REQUEST['import_ids']
+            ]
         ]);
         // Trigger extension attribute definition sync
         PluginJamfMobileSync::syncExtensionAttributeDefinitions();
         PluginJamfComputerSync::syncExtensionAttributeDefinitions();
         // Import the requested device(s)
         foreach ($toimport as $data) {
+            $glpi_itemtype = $_REQUEST['itemtype_overrides'][$data['id']] ?? $data['type'];
             if ($data['jamf_type'] === 'MobileDevice') {
-                PluginJamfMobileSync::import($data['type'], $data['jamf_items_id']);
+                PluginJamfMobileSync::import($glpi_itemtype, $data['jamf_items_id']);
             } else {
-                PluginJamfComputerSync::import($data['type'], $data['jamf_items_id']);
+                PluginJamfComputerSync::import($glpi_itemtype, $data['jamf_items_id']);
             }
         }
     } else {

--- a/ajax/merge.php
+++ b/ajax/merge.php
@@ -54,6 +54,10 @@ if ($_REQUEST['action'] === 'merge') {
     // Trigger extension attribute definition sync
     PluginJamfMobileSync::syncExtensionAttributeDefinitions();
     PluginJamfComputerSync::syncExtensionAttributeDefinitions();
+    $supported_glpi_types = [
+        'Computer' => PluginJamfComputerSync::getSupportedGlpiItemtypes(),
+        'MobileDevice' => PluginJamfMobileSync::getSupportedGlpiItemtypes()
+    ];
     // An array of item IDs is required
     if (isset($_REQUEST['item_ids']) && is_array($_REQUEST['item_ids'])) {
         $failures  = 0;
@@ -65,7 +69,7 @@ if ($_REQUEST['action'] === 'merge') {
             $jamf_id  = $data['jamf_id'];
             $itemtype = $data['itemtype'];
 
-            if (($itemtype !== 'Computer') && ($itemtype !== 'Phone')) {
+            if (!in_array($itemtype, $supported_glpi_types[$data['jamf_type']])) {
                 // Invalid itemtype for a mobile device
                 throw new RuntimeException('Invalid itemtype!');
             }

--- a/templates/import.html.twig
+++ b/templates/import.html.twig
@@ -28,6 +28,7 @@
  * -------------------------------------------------------------------------
  */
 #}
+{% import 'components/form/fields_macros.html.twig' as fields %}
 
 <form>
     {{ include('components/pager.html.twig', {
@@ -57,14 +58,26 @@
                     {% set import_checkbox %}
                         <input type="checkbox" name="import_{{ data.id }}" class="form-check-input massive_action_checkbox">
                     {% endset %}
-                    <tr>
+                    <tr data-import-id="{{ data.id }}">
                         <td>{{ import_checkbox }}</td>
                         <td>{{ data.jamf_items_id }}</td>
                         <td>{{ data.jamf_type }}</td>
                         <td>
                             <a href="{{ call('PluginJamf' ~ data.jamf_type ~ '::getJamfDeviceURL', [data.jamf_items_id]) }}">{{ data.name }}</a>
                         </td>
-                        <td>{{ data.type }}</td>
+                        {% if data.jamf_type == 'MobileDevice' %}
+                            <td>
+                                {{ fields.dropdownArrayField('glpi_type', data.type, {
+                                    'Phone': 'Phone'|itemtype_name,
+                                    'Computer': 'Computer'|itemtype_name,
+                                }, null, {
+                                    no_label: true,
+                                    full_width: true,
+                                }) }}
+                            </td>
+                        {% else %}
+                            <td>{{ data.type|itemtype_name }}</td>
+                        {% endif %}
                         <td class="{{ data.udid is empty ? 'font-italic' : '' }}">
                             {{ data.udid is not empty ? data.udid : _x('message', 'Not collected during discovery', 'jamf') }}
                         </td>
@@ -90,12 +103,19 @@
                 const import_ids = $(':checkbox:checked').filter(':not([name^="_checkall"])').map(function() {
                     return this.name.replace("import","").substring(1).split('_');
                 }).toArray();
+                const itemtype_overrides = {};
+                $('select[name="glpi_type"]').each((i, e) => {
+                    const itemtype = $(e).val();
+                    const id = $(e).closest('tr').attr('data-import-id');
+                    itemtype_overrides[id] = itemtype;
+                });
                 $.ajax({
                     type: "POST",
                     url: "{{ get_plugin_web_dir('jamf') }}/ajax/import.php",
                     data: {
                         action: "import",
-                        import_ids: import_ids
+                        import_ids: import_ids,
+                        itemtype_overrides: itemtype_overrides
                     },
                     contentType: 'application/json',
                     beforeSend: () => {

--- a/templates/merge.html.twig
+++ b/templates/merge.html.twig
@@ -58,18 +58,31 @@
                         <td>
                             <a href="{{ call('PluginJamf' ~ data.jamf_type ~ '::getJamfDeviceURL', [data.jamf_items_id]) }}">{{ data.name }}</a>
                         </td>
-                        <td>{{ data.type }}</td>
+                        <td>
+                            {% if supported_glpi_types[data.jamf_type]|length > 0 %}
+                                {{ fields.dropdownArrayField('glpi_type', data.type, supported_glpi_types[data.jamf_type], null, {
+                                    no_label: true,
+                                    full_width: true,
+                                }) }}
+                            {% else %}
+                                {{ data.type|itemtype_name }}
+                            {% endif %}
+                        </td>
                         <td>{{ data.jamf_type }}</td>
                         <td class="{{ data.udid is empty ? 'font-italic' : '' }}">
                             {{ data.udid is not empty ? data.udid : _x('message', 'Not collected during discovery', 'jamf') }}
                         </td>
                         <td>{{ data.date_discover|formatted_datetime }}</td>
                         <td>
-                            {{ fields.dropdownField(data.type, 'items_id', data.guessed_item, null, {
-                                no_label: true,
-                                full_width: true,
-                                used: linked[data.type]|default([])|column('items_id')
-                            }) }}
+                            {% for glpi_type in supported_glpi_types[data.jamf_type] %}
+                                <span class="{{ glpi_type != data.type ? 'd-none' : '' }}" data-itemtype="{{ glpi_type }}">
+                                    {{ fields.dropdownField(glpi_type, 'items_id', data.guessed_item[glpi_type], null, {
+                                        no_label: true,
+                                        full_width: true,
+                                        used: linked[glpi_type]|default([])|column('items_id'),
+                                    }) }}
+                                </span>
+                            {% endfor %}
                         </td>
                     </tr>
                 {% endfor %}
@@ -93,12 +106,11 @@
                 for (let i = 1; i < row_count; i++) {
                     const row = table.rows[i];
                     const jamf_id = row.cells[0].innerText;
-                    const itemtype = row.cells[2].innerText;
+                    const itemtype = $(row.cells[2]).find('select')[0].value;
                     const jamf_type = row.cells[3].innerText;
-                    const glpi_sel = $(row.cells[6]).find('select')[0];
+                    const glpi_sel = $(row.cells[6]).find('span[data-itemtype]:not(.d-none) select')[0];
                     const glpi_id = glpi_sel.value;
                     if (glpi_id && glpi_id > 0) {
-                        data = [];
                         post_data[glpi_id] = {'itemtype': itemtype, 'jamf_id': jamf_id, 'jamf_type': jamf_type};
                     }
                 }
@@ -115,6 +127,11 @@
                     }
                 });
             }
+            $('select[name="glpi_type"]').on('change', (e) => {
+                const selection = $(e.target).val();
+                $(e.target).closest('tr').find('span[data-itemtype]').addClass('d-none');
+                $(e.target).closest('tr').find('span[data-itemtype="' + selection + '"]').removeClass('d-none');
+            });
         </script>
     </div>
 </form>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.

## Description

This was a feature that was promised in the early days of this plugin but seems to have been forgotten/accidentally removed when I focused on bringing "smart phone" features to GLPI itself. I am reviving the feature based on a community request on the forum and also to later support custom asset types coming in GLPI 11.