### PR TITLE
3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+## [3.2.1] - 2026-04-30
+
 ### Fixed
 
 - Fix failed to open stream: No such file or directory (`jamf/tools/pmv.json`)

--- a/jamf.xml
+++ b/jamf.xml
@@ -39,6 +39,11 @@ Utilisation
    </authors>
    <versions>
       <version>
+         <num>3.2.1</num>
+         <compatibility>~11.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/jamf/releases/download/3.2.1/glpi-jamf-3.2.1.tar.bz2</download_url>
+      </version>
+      <version>
          <num>3.2.0</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/jamf/releases/download/3.2.0/glpi-jamf-3.2.0.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -34,7 +34,7 @@ use Glpi\Plugin\Hooks;
 use function Safe\define;
 use function Safe\preg_replace;
 
-define('PLUGIN_JAMF_VERSION', '3.2.0');
+define('PLUGIN_JAMF_VERSION', '3.2.1');
 define('PLUGIN_JAMF_MIN_GLPI', '11.0.0');
 define('PLUGIN_JAMF_MAX_GLPI', '11.0.99');
 


### PR DESCRIPTION
## [3.2.1] - 2026-04-30

### Fixed

- Fix failed to open stream: No such file or directory (`jamf/tools/pmv.json`)